### PR TITLE
rewrite flush #4 追加

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -18,7 +18,8 @@
   },
   "mappings": {
     "sql": "./sql",
-    "wp-content/uploads": "./uploads"
+    "wp-content/uploads": "./uploads",
+    "wp-cli.local.yml": "./wp-cli.local.yml"
   },
   "config": {
     "WP_DEBUG": false

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "wp:env": "wp-env",
     "wp:start": "npm run wp:env start",
     "wp:restart": "npm run wp:env start --update",
-    "wp:setup": "npm run wp:start && npm run db:import",
+    "wp:setup": "npm run wp:start && npm run db:import && npm run wp:env run cli 'wp rewrite flush --hard'",
     "wp:destroy": "npm run wp:env destroy",
     "lint:check": "npm run lint:style && npm run lint:es",
     "lint:style": "stylelint 'assets/**/*.{css,scss}'",

--- a/wp-cli.local.yml
+++ b/wp-cli.local.yml
@@ -1,0 +1,2 @@
+# Required to operate .htaccess file via wp-cli.
+apache_modules: mod_rewrite


### PR DESCRIPTION
#4　を解決するためのコードになります。

wp-envが扱うwp-cli用のコンテナ内で.htaccessを認識できるようにする必要がありますが、wp-cli用のコンフィグファイルをマッピングしコンテナ内に渡すことで実現しています。
これにより wp-cli が `rewrite flush --hard` のサブコマンドを正しく実行し.htaccessを作成できるようになります。

独立したコマンドまでは必要ないかと考えエイリアスは用意せずに `wp:setup` 内でのみ実行するようにしていますが、
`wp-cli.local.yml` の場所とあわせて意見いただきたいです…！